### PR TITLE
(GH-10) Author tool config simple script

### DIFF
--- a/sample/test_tool/0.1.0/content/entrypoint.ps1
+++ b/sample/test_tool/0.1.0/content/entrypoint.ps1
@@ -1,0 +1,13 @@
+param(
+    [Alias('f')]
+    [Switch]$Fail
+)
+
+"This is a script used to test PRM"
+"Contents of target dir: "
+Get-ChildItem
+
+if ($Fail) {
+  Write-Error "-f flag was triggered, the script will now exit with error code 1"
+  exit 1
+}

--- a/sample/test_tool/0.1.0/content/entrypoint.sh
+++ b/sample/test_tool/0.1.0/content/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "This is a script used to test PRM"
+echo "Contents of target dir: "
+ls
+
+while getopts 'f' opt; do
+    case $opt in
+        f)
+        echo "-f flag was triggered, the script will now exit with error code 1" >&2
+        exit 1;
+    esac
+done

--- a/sample/test_tool/0.1.0/generated.Dockerfile
+++ b/sample/test_tool/0.1.0/generated.Dockerfile
@@ -1,0 +1,6 @@
+FROM puppet/puppet-agent:5.5.0
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4528B6CD9E61EF26
+COPY ./content/* /tmp/ 
+VOLUME [ /code, /cache ]
+WORKDIR /code
+ENTRYPOINT ["/tmp/entrypoint.sh"]

--- a/sample/test_tool/0.1.0/prm-config.yml
+++ b/sample/test_tool/0.1.0/prm-config.yml
@@ -1,0 +1,16 @@
+---
+plugin:
+  author: sample
+  id: test_tool
+  display: Test Tool Config
+  version: 0.1.0
+  upstream_project_url: https://puppet.com/docs/puppet/7/lang_template_epp.html
+
+common:
+  can_validate: false
+  needs_write_access: false
+  use_script: 'entrypoint'
+  # No longer necessary as default args are handled in the scripts
+  # default_args: []
+  success_exit_code: 0
+  interleave_stdout_err: false


### PR DESCRIPTION
In this commit a tool configuration has been added for the purpose of
testing `prm exec` functionality. When the tool is executed, it will return the contents of
the code directory it has been provided to execute upon.

In addition, adding the `-f` flag to the `toolArgs` will cause the tool
to exit with an exit code of 1, for testing purposes.

[Issue link](https://github.com/puppetlabs/prm/issues/10)